### PR TITLE
Add EF Core Sqlite provider

### DIFF
--- a/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/InventoryManagementSystem.csproj
+++ b/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/InventoryManagementSystem.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="MahApps.Metro" Version="2.4.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- add Microsoft.EntityFrameworkCore.Sqlite package reference so SQLite provider assemblies ship with executable

## Testing
- `dotnet build StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/InventoryManagementSystem.csproj -c Debug` (fails: command not found)
- `apt-get update` (fails: repository not signed / 403)


------
https://chatgpt.com/codex/tasks/task_e_68bc15e77f7c83249c59d524370ed1c3