### PR TITLE
Add configurable database connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,12 @@ The system is developed using a Two-layers architecture: presentation and busine
 ## Technologies Used
 
 The system is developed using **C#**, **WPF**, **Entity Framework Core**, and **SQL**.
+
+## Configuration
+
+The application stores its data in a SQLite database. By default, the database file `inventory.db` is created in the application's base directory. You can change this location in two ways:
+
+1. **Edit `appsettings.json`** – Update the connection string in `StoreManagementSystem/ClassLibrary1/ClassLibrary1/appsettings.json`.
+2. **Set an environment variable** – Specify a custom path with the `DatabasePath` environment variable to override the location defined in the configuration file.
+
+The context will automatically build a SQLite connection string from these settings.

--- a/StoreManagementSystem/ClassLibrary1/ClassLibrary1/ClassLibrary1.csproj
+++ b/StoreManagementSystem/ClassLibrary1/ClassLibrary1/ClassLibrary1.csproj
@@ -13,6 +13,15 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/StoreManagementSystem/ClassLibrary1/ClassLibrary1/Context.cs
+++ b/StoreManagementSystem/ClassLibrary1/ClassLibrary1/Context.cs
@@ -1,5 +1,6 @@
 ﻿using InventoryManagementSystem;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -14,10 +15,29 @@ namespace InventoryManagementSystem
         {
                 private readonly string _connectionString;
 
-                public Context(string? connectionString = null)
+                public Context()
                 {
                         var basePath = AppDomain.CurrentDomain.BaseDirectory;
-                        _connectionString = connectionString ?? $"Data Source={Path.Combine(basePath, \"inventory.db\")}";
+
+                        IConfiguration config = new ConfigurationBuilder()
+                                .SetBasePath(basePath)
+                                .AddJsonFile("appsettings.json", optional: true)
+                                .AddEnvironmentVariables()
+                                .Build();
+
+                        var connectionString = config.GetConnectionString("DefaultConnection");
+                        var pathOverride = config["DatabasePath"];
+                        if (!string.IsNullOrWhiteSpace(pathOverride))
+                        {
+                                connectionString = $"Data Source={pathOverride}";
+                        }
+
+                        if (string.IsNullOrWhiteSpace(connectionString))
+                        {
+                                connectionString = $"Data Source={Path.Combine(basePath, "inventory.db")}";
+                        }
+
+                        _connectionString = connectionString;
                 }
 
                 public DbSet<Inventory> Inventories { get; set; }

--- a/StoreManagementSystem/ClassLibrary1/ClassLibrary1/appsettings.json
+++ b/StoreManagementSystem/ClassLibrary1/ClassLibrary1/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=inventory.db"
+  }
+}


### PR DESCRIPTION
## Summary
- read connection strings from appsettings.json and environment variables
- add default SQLite connection string and allow path overrides
- document how to configure database location

## Testing
- `dotnet build StoreManagementSystem/ClassLibrary1/ClassLibrary1/ClassLibrary1.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bc15e94e4c8324b5b966132274154d