### PR TITLE
Add admin setup window and startup logic

### DIFF
--- a/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/App.xaml
+++ b/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/App.xaml
@@ -1,9 +1,8 @@
-﻿<Application x:Class="InventoryManagementSystem.App"
+<Application x:Class="InventoryManagementSystem.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:InventoryManagementSystem"
-             StartupUri="View/LoginView.xaml">
+             xmlns:local="clr-namespace:InventoryManagementSystem">
     <Application.Resources>
-         
+
     </Application.Resources>
 </Application>

--- a/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/App.xaml.cs
+++ b/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/App.xaml.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
+using Microsoft.EntityFrameworkCore;
 
 namespace InventoryManagementSystem
 {
@@ -13,5 +9,23 @@ namespace InventoryManagementSystem
     /// </summary>
     public partial class App : Application
     {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+
+            using (var context = new Context())
+            {
+                context.Database.EnsureCreated();
+
+                if (!context.Users.Any())
+                {
+                    var setupWindow = new View.AdminSetupView();
+                    setupWindow.ShowDialog();
+                }
+            }
+
+            var loginView = new View.LoginView();
+            loginView.Show();
+        }
     }
 }

--- a/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/View/AdminSetupView.xaml
+++ b/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/View/AdminSetupView.xaml
@@ -1,0 +1,22 @@
+<Window x:Class="InventoryManagementSystem.View.AdminSetupView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Admin Setup" Height="200" Width="300">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Margin="0,0,0,10">
+            <TextBlock Text="Username"/>
+            <TextBox x:Name="txtUser" Width="200"/>
+        </StackPanel>
+        <StackPanel Grid.Row="1" Margin="0,0,0,10">
+            <TextBlock Text="Password"/>
+            <PasswordBox x:Name="txtPassword" Width="200"/>
+        </StackPanel>
+        <Button Grid.Row="2" Content="Create" Width="80" HorizontalAlignment="Center" Click="Create_Click"/>
+    </Grid>
+</Window>

--- a/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/View/AdminSetupView.xaml.cs
+++ b/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/View/AdminSetupView.xaml.cs
@@ -1,0 +1,33 @@
+using System.Windows;
+
+namespace InventoryManagementSystem.View
+{
+    /// <summary>
+    /// Interaction logic for AdminSetupView.xaml
+    /// </summary>
+    public partial class AdminSetupView : Window
+    {
+        public AdminSetupView()
+        {
+            InitializeComponent();
+        }
+
+        private void Create_Click(object sender, RoutedEventArgs e)
+        {
+            using (var context = new Context())
+            {
+                var user = new User
+                {
+                    Namer = txtUser.Text,
+                    Password = txtPassword.Password
+                };
+
+                context.Users.Add(user);
+                context.SaveChanges();
+            }
+
+            DialogResult = true;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Override application startup to ensure database and prompt for admin creation when no users exist
- Provide `AdminSetupView` for capturing initial admin credentials

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc181373608324ae93ee3c519b70c4