### PR TITLE
style: apply shared window chrome to admin setup

### DIFF
--- a/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/App.xaml
+++ b/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/App.xaml
@@ -3,6 +3,58 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:InventoryManagementSystem">
     <Application.Resources>
+        <Style x:Key="ChromelessWindowStyle" TargetType="Window">
+            <Setter Property="WindowStyle" Value="None" />
+            <Setter Property="ResizeMode" Value="NoResize" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="AllowsTransparency" Value="True" />
+            <Setter Property="WindowStartupLocation" Value="CenterScreen" />
+        </Style>
 
+        <Style x:Key="GradientBorderStyle" TargetType="Border">
+            <Setter Property="CornerRadius" Value="15" />
+            <Setter Property="BorderThickness" Value="5" />
+            <Setter Property="Opacity" Value="0.90" />
+            <Setter Property="BorderBrush">
+                <Setter.Value>
+                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                        <GradientStop Color="#462AD8" Offset="0" />
+                        <GradientStop Color="#DA34AE" Offset="0.75" />
+                        <GradientStop Color="#8A16C1" Offset="1" />
+                    </LinearGradientBrush>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="Background">
+                <Setter.Value>
+                    <LinearGradientBrush StartPoint="0,1" EndPoint="1,0">
+                        <GradientStop Color="#060531" Offset="0.4" />
+                        <GradientStop Color="#FF332A6F" Offset="1" />
+                    </LinearGradientBrush>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="PrimaryButtonStyle" TargetType="Button">
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="FontFamily" Value="Montserrat" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Background" Value="#462AD8" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border Width="150" Height="40" CornerRadius="20" Background="{TemplateBinding Background}">
+                            <ContentPresenter VerticalAlignment="Center" HorizontalAlignment="Center" />
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#28AEED" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
     </Application.Resources>
 </Application>

--- a/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/View/AdminSetupView.xaml
+++ b/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/View/AdminSetupView.xaml
@@ -1,22 +1,148 @@
 <Window x:Class="InventoryManagementSystem.View.AdminSetupView"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Admin Setup" Height="200" Width="300">
-    <Grid Margin="10">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
+        Title="Admin Setup" Height="300" Width="400"
+        Style="{StaticResource ChromelessWindowStyle}">
+    <Border CornerRadius="15">
+        <Border.Background>
+            <ImageBrush ImageSource="../Images/storage.jpg" Stretch="None"/>
+        </Border.Background>
+        <Border Style="{StaticResource GradientBorderStyle}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="30"/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
 
-        <StackPanel Grid.Row="0" Margin="0,0,0,10">
-            <TextBlock Text="Username"/>
-            <TextBox x:Name="txtUser" Width="200"/>
-        </StackPanel>
-        <StackPanel Grid.Row="1" Margin="0,0,0,10">
-            <TextBlock Text="Password"/>
-            <PasswordBox x:Name="txtPassword" Width="200"/>
-        </StackPanel>
-        <Button Grid.Row="2" Content="Create" Width="80" HorizontalAlignment="Center" Click="Create_Click"/>
-    </Grid>
+                <Grid Grid.Row="0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition/>
+                        <ColumnDefinition Width="25"/>
+                        <ColumnDefinition Width="25"/>
+                        <ColumnDefinition Width="5"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="ADMIN SETUP"
+                               Foreground="DarkGray"
+                               FontSize="10"
+                               FontFamily="Montserrat"
+                               VerticalAlignment="Center"
+                               Margin="10,0,0,0"/>
+                    <Button x:Name="btnMinimize"
+                            BorderThickness="2"
+                            Content="-"
+                            Foreground="White"
+                            FontSize="16"
+                            FontFamily="Montserrat"
+                            Cursor="Hand"
+                            Grid.Column="1"
+                            Click="btnMinimize_Click">
+                        <Button.Style>
+                            <Style TargetType="Button">
+                                <Setter Property="Background" Value="#28AEED"/>
+                                <Style.Triggers>
+                                    <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter Property="Background" Value="#278BEF"/>
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                        <Button.Template>
+                            <ControlTemplate TargetType="Button">
+                                <Border Width="18" Height="18" CornerRadius="9" Background="{TemplateBinding Background}">
+                                    <ContentPresenter VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                </Border>
+                            </ControlTemplate>
+                        </Button.Template>
+                    </Button>
+                    <Button x:Name="btnClose"
+                            BorderThickness="0"
+                            Content="X"
+                            Foreground="White"
+                            FontSize="12"
+                            FontFamily="Montserrat"
+                            Cursor="Hand"
+                            Grid.Column="2"
+                            Click="btnClose_Click">
+                        <Button.Style>
+                            <Style TargetType="Button">
+                                <Setter Property="Background" Value="#DA34AE"/>
+                                <Style.Triggers>
+                                    <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter Property="Background" Value="#C62DAE"/>
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                        <Button.Template>
+                            <ControlTemplate TargetType="Button">
+                                <Border Width="18" Height="18" CornerRadius="9" Background="{TemplateBinding Background}">
+                                    <ContentPresenter VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                </Border>
+                            </ControlTemplate>
+                        </Button.Template>
+                    </Button>
+                </Grid>
+
+                <Grid Grid.Row="1" Margin="10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <StackPanel Grid.Row="0" Margin="0,0,0,10">
+                        <TextBlock Text="Username"
+                                   Foreground="DarkGray"
+                                   FontSize="12"
+                                   FontWeight="Medium"
+                                   FontFamily="Montserrat"/>
+                        <TextBox x:Name="txtUser"
+                                 Width="200"
+                                 FontSize="13"
+                                 FontWeight="Medium"
+                                 FontFamily="Montserrat"
+                                 Foreground="White"
+                                 CaretBrush="LightGray"
+                                 BorderBrush="DarkGray"
+                                 BorderThickness="0,0,0,2"
+                                 Height="28"
+                                 VerticalContentAlignment="Center">
+                            <TextBox.Background>
+                                <ImageBrush Opacity="0" Stretch="None" AlignmentX="Left"/>
+                            </TextBox.Background>
+                        </TextBox>
+                    </StackPanel>
+
+                    <StackPanel Grid.Row="1" Margin="0,0,0,10">
+                        <TextBlock Text="Password"
+                                   Foreground="DarkGray"
+                                   FontSize="12"
+                                   FontWeight="Medium"
+                                   FontFamily="Montserrat"/>
+                        <PasswordBox x:Name="txtPassword"
+                                     Width="200"
+                                     FontSize="13"
+                                     FontWeight="Medium"
+                                     FontFamily="Montserrat"
+                                     Foreground="White"
+                                     CaretBrush="LightGray"
+                                     BorderBrush="DarkGray"
+                                     BorderThickness="0,0,0,2"
+                                     Height="28"
+                                     VerticalContentAlignment="Center">
+                            <PasswordBox.Background>
+                                <ImageBrush Opacity="0" Stretch="None" AlignmentX="Left"/>
+                            </PasswordBox.Background>
+                        </PasswordBox>
+                    </StackPanel>
+
+                    <Button Grid.Row="2"
+                            Content="Create"
+                            HorizontalAlignment="Center"
+                            Click="Create_Click"
+                            Style="{StaticResource PrimaryButtonStyle}"/>
+                </Grid>
+            </Grid>
+        </Border>
+    </Border>
 </Window>

--- a/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/View/AdminSetupView.xaml.cs
+++ b/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/View/AdminSetupView.xaml.cs
@@ -29,5 +29,15 @@ namespace InventoryManagementSystem.View
             DialogResult = true;
             Close();
         }
+
+        private void btnClose_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        private void btnMinimize_Click(object sender, RoutedEventArgs e)
+        {
+            WindowState = WindowState.Minimized;
+        }
     }
 }

--- a/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/View/LoginView.xaml
+++ b/StoreManagementSystem/ClassLibrary1/InventoryManagementSystem/View/LoginView.xaml
@@ -7,34 +7,14 @@
         mc:Ignorable="d"
         Title="LoginView" Height="450" Width="800"
         MinHeight="550"
-        WindowStyle="None"
-        ResizeMode="NoResize"
-        WindowStartupLocation="CenterScreen"
-        Background="Transparent"
-        AllowsTransparency="True"
-        >
+        Style="{StaticResource ChromelessWindowStyle}">
 
     <Border CornerRadius="15">
         <Border.Background>
             <ImageBrush ImageSource="../Images/storage.jpg"
                         Stretch="None"/>
         </Border.Background>
-        <Border CornerRadius="15"                    
-            BorderThickness="5"
-            Opacity="0.90">
-            <Border.BorderBrush>
-                <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                    <GradientStop Color="#462AD8" Offset="0"/>
-                    <GradientStop Color="#DA34AE" Offset="0.75"/>
-                    <GradientStop Color="#8A16C1" Offset="1"/>
-                </LinearGradientBrush>
-            </Border.BorderBrush>
-            <Border.Background>
-                <LinearGradientBrush StartPoint="0,1" EndPoint="1,0">
-                    <GradientStop Color="#060531" Offset="0.4"/>
-                    <GradientStop Color="#FF332A6F" Offset="1"/>
-                </LinearGradientBrush>
-            </Border.Background>
+        <Border Style="{StaticResource GradientBorderStyle}">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="30"/>
@@ -197,36 +177,11 @@
                         </PasswordBox.Background>
                     </PasswordBox>
 
-                    <Button x:Name="btnLogin"                          
-                            BorderThickness="0"
+                    <Button x:Name="btnLogin"
                             Content="LOG IN"
-                            Foreground="White"
-                            FontSize="12"
-                            FontFamily="Montserrat"
-                            Cursor="Hand"                           
-                            Margin="0,50,0,0" Click="btnLogin_Click"
-                           >
-                        <Button.Style>
-                            <Style TargetType="Button">
-                                <Setter Property="Background" Value="#462AD8"/>
-                                <Style.Triggers>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter Property="Background" Value="#28AEED"/>
-                                    </Trigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Button.Style>
-                        <Button.Template>
-                            <ControlTemplate TargetType="Button">
-                                <Border Width="150" Height="40"
-                                        CornerRadius="20"
-                                        Background="#FF4841C6">
-                                    <ContentPresenter VerticalAlignment="Center"
-                                                      HorizontalAlignment="Center"/>
-                                </Border>
-                            </ControlTemplate>
-                        </Button.Template>
-                    </Button>
+                            Margin="0,50,0,0"
+                            Click="btnLogin_Click"
+                            Style="{StaticResource PrimaryButtonStyle}"/>
 
                 </StackPanel>
             </Grid>


### PR DESCRIPTION
## Summary
- add reusable window, border, and button styles
- style Login and Admin Setup windows using shared resources
- match Admin Setup view to Montserrat design with chrome buttons

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1a5940808324ade6620caa0ffecc